### PR TITLE
[Sol] 미로 탐색(#2178), 타겟넘버(#프로그래머스 타겟넘버)

### DIFF
--- a/Algorithm_Study/Algorithm_Study.xcodeproj/project.pbxproj
+++ b/Algorithm_Study/Algorithm_Study.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		023A984627B800C100117DA2 /* 9012.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A984527B800C100117DA2 /* 9012.swift */; };
 		0283F7B327B95401006646D3 /* 10773.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0283F7B227B95401006646D3 /* 10773.swift */; };
 		02B5CB2D27C0CADA00981B7B /* 10845.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B5CB2C27C0CADA00981B7B /* 10845.swift */; };
+		02F8198627DE40570084F0AD /* 2178.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198527DE40570084F0AD /* 2178.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -43,6 +44,7 @@
 		023A984527B800C100117DA2 /* 9012.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 9012.swift; sourceTree = "<group>"; };
 		0283F7B227B95401006646D3 /* 10773.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 10773.swift; sourceTree = "<group>"; };
 		02B5CB2C27C0CADA00981B7B /* 10845.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 10845.swift; sourceTree = "<group>"; };
+		02F8198527DE40570084F0AD /* 2178.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2178.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 				02B5CB2F27C0CAE800981B7B /* Week3 */,
 				023A3A4927D4C8D600F56686 /* Week4 */,
 				023A3A4427D4B08100F56686 /* Week5 */,
+				02F8198727DE405A0084F0AD /* Week6 */,
 			);
 			path = Algorithm_Study;
 			sourceTree = "<group>";
@@ -119,6 +122,14 @@
 				02227B0A27C53B4A00E7CFC5 /* 14713.swift */,
 			);
 			path = Week3;
+			sourceTree = "<group>";
+		};
+		02F8198727DE405A0084F0AD /* Week6 */ = {
+			isa = PBXGroup;
+			children = (
+				02F8198527DE40570084F0AD /* 2178.swift */,
+			);
+			path = Week6;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -183,6 +194,7 @@
 				02227B0B27C53B4A00E7CFC5 /* 14713.swift in Sources */,
 				0209E8A327C3C04900AFCF71 /* 1966.swift in Sources */,
 				023A3A4627D4B0AB00F56686 /* 1260.swift in Sources */,
+				02F8198627DE40570084F0AD /* 2178.swift in Sources */,
 				023A983C27B7F34B00117DA2 /* main.swift in Sources */,
 				023A984627B800C100117DA2 /* 9012.swift in Sources */,
 				023A3A4C27D4C8D600F56686 /* 10866.swift in Sources */,

--- a/Algorithm_Study/Algorithm_Study.xcodeproj/project.pbxproj
+++ b/Algorithm_Study/Algorithm_Study.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0283F7B327B95401006646D3 /* 10773.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0283F7B227B95401006646D3 /* 10773.swift */; };
 		02B5CB2D27C0CADA00981B7B /* 10845.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B5CB2C27C0CADA00981B7B /* 10845.swift */; };
 		02F8198627DE40570084F0AD /* 2178.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198527DE40570084F0AD /* 2178.swift */; };
+		02F8198927DE41200084F0AD /* 타겟넘버.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F8198827DE41200084F0AD /* 타겟넘버.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -45,6 +46,7 @@
 		0283F7B227B95401006646D3 /* 10773.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 10773.swift; sourceTree = "<group>"; };
 		02B5CB2C27C0CADA00981B7B /* 10845.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 10845.swift; sourceTree = "<group>"; };
 		02F8198527DE40570084F0AD /* 2178.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2178.swift; sourceTree = "<group>"; };
+		02F8198827DE41200084F0AD /* 타겟넘버.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "타겟넘버.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +130,7 @@
 			isa = PBXGroup;
 			children = (
 				02F8198527DE40570084F0AD /* 2178.swift */,
+				02F8198827DE41200084F0AD /* 타겟넘버.swift */,
 			);
 			path = Week6;
 			sourceTree = "<group>";
@@ -200,6 +203,7 @@
 				023A3A4C27D4C8D600F56686 /* 10866.swift in Sources */,
 				023A3A4D27D4C8D600F56686 /* 1021.swift in Sources */,
 				02B5CB2D27C0CADA00981B7B /* 10845.swift in Sources */,
+				02F8198927DE41200084F0AD /* 타겟넘버.swift in Sources */,
 				023A984327B7F6CC00117DA2 /* 10828.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Algorithm_Study/Algorithm_Study/Week6/2178.swift
+++ b/Algorithm_Study/Algorithm_Study/Week6/2178.swift
@@ -1,0 +1,44 @@
+//
+//  2178.swift
+//  Algorithm_Study
+//
+//  Created by 김한솔 on 2022/03/13.
+//
+
+import Foundation
+
+func mySolutionOf2178() {
+    
+    func bfs(graph: [[Int]], N: Int, M: Int) -> Int {
+        var graph = graph
+        var distance = [[Int]](repeating: [Int](repeating: 0, count: M), count: N)
+        distance[0][0] = 1
+        var toVisitQueue = [(x: 0, y: 0)]
+        
+        while !toVisitQueue.isEmpty {
+            let position = toVisitQueue.removeFirst()
+            
+            for i in [(x: 1, y: 0), (x: -1, y: 0), (x: 0, y: 1), (x: 0, y: -1)] {
+                let (dx, dy) = (position.x + i.x, position.y + i.y) // nextPosition = (dx, dy)
+                
+                if (0..<N).contains(dy) && (0..<M).contains(dx) && graph[dy][dx] == 1 { // dx, dy가 그래프 내의 좌표이고, 그래프 상 (dx,dy)가 1인 경우
+                    graph[dy][dx] = 0
+                    toVisitQueue.append((dx, dy))
+                    distance[dy][dx] = distance[position.y][position.x] + 1
+                }
+            }
+        }
+        
+        return distance[N-1][M-1]
+    }
+    
+    var maze = [[Int]]()
+    let input = readLine()!.split(separator: " ").map{Int(String($0))!}
+    let N = input[0], M = input[1]
+    
+    for _ in 0..<N { // maze 만들기
+        maze.append(readLine()!.map{Int(String($0))!})
+    }
+    
+    print(bfs(graph: maze, N: N, M: M))
+}

--- a/Algorithm_Study/Algorithm_Study/Week6/타겟넘버.swift
+++ b/Algorithm_Study/Algorithm_Study/Week6/타겟넘버.swift
@@ -1,0 +1,29 @@
+//
+//  타겟넘버.swift
+//  Algorithm_Study
+//
+//  Created by 김한솔 on 2022/03/14.
+//
+
+import Foundation
+
+func mySolutionOf타겟넘버(numbers: [Int], target: Int) -> Int {
+    var answer = 0
+    
+    func DFS(sum: Int, index: Int) {
+        if index == (numbers.count-1) && sum == target {
+            answer += 1
+            return
+        }
+        
+        guard index + 1 < numbers.count else {return}
+        
+        DFS(sum: sum + numbers[index+1], index: index + 1)
+        DFS(sum: sum - numbers[index+1], index: index + 1)
+    }
+
+    DFS(sum: 0, index: -1)
+    
+    
+    return answer
+}

--- a/Algorithm_Study/Algorithm_Study/main.swift
+++ b/Algorithm_Study/Algorithm_Study/main.swift
@@ -38,3 +38,6 @@ mySolutionOf1260()
 
 //0x09BFS 백준 2178 출력
 mySolutionOf2178()
+
+//0x09BFS 프로그래머스 타겟넘버 출력
+print(mySolutionOf타겟넘버(numbers: [1,1,1,1,1], target: 3))

--- a/Algorithm_Study/Algorithm_Study/main.swift
+++ b/Algorithm_Study/Algorithm_Study/main.swift
@@ -35,3 +35,6 @@ mySolutionOf1021()
 
 //0x09BFS 백준 1260 출력
 mySolutionOf1260()
+
+//0x09BFS 백준 2178 출력
+mySolutionOf2178()

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@
 ## BFS
 
 - [#BOJ1260](https://www.acmicpc.net/problem/1260) [[풀이]](./Algorithm_Study/Algorithm_Study/Week5/1260.swift)
+
+- [#BOJ2178](https://www.acmicpc.net/problem/2178) [[풀이]](./Algorithm_Study/Algorithm_Study/Week6/2178.swift)
+
+- [#Programmers-타겟넘버](https://programmers.co.kr/learn/courses/30/lessons/43165#qna) [[풀이]](./Algorithm_Study/Algorithm_Study/Week6/타겟넘버.swift)


### PR DESCRIPTION
# BFS
### 2178-미로 탐색
- 문제 풀이
```swift
func bfs(graph: [[Int]], N: Int, M: Int) -> Int {
    var graph = graph
    var distance = [[Int]](repeating: [Int](repeating: 0, count: M), count: N)
    distance[0][0] = 1
    graph[0][0] = 0
    var toVisitQueue = [(x: 0, y: 0)]
    
    while !toVisitQueue.isEmpty {
        let position = toVisitQueue.removeFirst()
        
        for i in [(x: 1, y: 0), (x: -1, y: 0), (x: 0, y: 1), (x: 0, y: -1)] {
            let (dx, dy) = (position.x + i.x, position.y + i.y) // nextPosition = (dx, dy)
            
            if (0..<N).contains(dy) && (0..<M).contains(dx) && graph[dy][dx] == 1 { // dx, dy가 그래프 내의 좌표이고, 그래프 상 (dx,dy)가 1인 경우
                graph[dy][dx] = 0
                toVisitQueue.append((dx, dy))
                distance[dy][dx] = distance[position.y][position.x] + 1
            }
        }
    }
    
    return distance[N-1][M-1]
}

var maze = [[Int]]()
let input = readLine()!.split(separator: " ").map{Int(String($0))!}
let N = input[0], M = input[1]

for _ in 0..<N { // maze 만들기
    maze.append(readLine()!.map{Int(String($0))!})
}

print(bfs(graph: maze, N: N, M: M))
```
- 시도한 접근 방법
  문제 로직을 짜는데 오래 걸렸습니다. 전 문제에서 사용했던 인접 행렬 그래프를 사용해서 문제에 접근하려 했는데, maze 상에서 이미 지나온 좌표의 값을 `1->0` 의 변경을 해주지 않아서 처음부터 구조를 다시 짜는 등 많은 시행착오가 있었습니다. 그러다가 결국은 이동한 거리를 구해야하기 때문에 distance라는 행렬을 만들어, (0,0)에서부터 해당 지점까지 가는데 몇 걸음을 가야하는지를 나타내도록 했습니다. 그리고 앞서 말했던 것처럼, 이미 지나온 지점의 값을 0으로 만들어주어, 다시 되돌아갈 수 없도록 만들었습니다. 그리고 BFS를 이용해 다음 이동할 지점을 구하도록 했습니다.
  그리고, 미로의 (N-1,M-1) 지점으로 갈 수 있는 방향이 여러 개일 경우를 대비해, `if graph[dy][dx] == 1` 인 조건을 주었습니다. (N-1,M-1) 으로 갈 수 있는 최단거리의 경우가 제일 먼저 distance[N-1][M-1]를 걸음 수로 바꿔놓고 graph[N-1][M-1]을 0으로 만들어놨을 것이므로, 최단 거리보다 더 많은 걸음이 필요한 경우에는 graph[N-1][M-1] 이 1이 아닐 것이므로 distance[N-1][M-1]을 수정할 수 없습니다.
  예를 들어 아래의 그래프 경우에는,
  ```
  1011111
  1110001
  1000001
  1000001
  1000001
  1111111
  ```
  다음과 같은 모양의 distance 배열을 얻게 됩니다.
  ```
  [1, 0, 5, 6, 7, 8, 9],
  [2, 3, 4, 0, 0, 0, 10],
  [3, 0, 0, 0, 0, 0, 11],
  [4, 0, 0, 0, 0, 0, 12],
  [5, 0, 0, 0, 0, 0, 13],
  [6, 0, 0, 0, 0, 0, 14],
  [7, 8, 9,  10, 11, 12, 13]
  ```
---
### 타겟 넘버
- 문제 풀이
```swift
func mySolutionOf타겟넘버(numbers: [Int], target: Int) -> Int {
    var answer = 0
    
    func DFS(sum: Int, index: Int) {
        if index == (numbers.count-1) && sum == target {
            answer += 1
            return
        }
        
        guard index + 1 < numbers.count else {return}
        
        DFS(sum: sum + numbers[index+1], index: index + 1)
        DFS(sum: sum - numbers[index+1], index: index + 1)
    }

    DFS(sum: 0, index: -1)
    
    
    return answer
}
```
- 시도한 접근 방법
  이번 문제는 재귀를 사용하지 않고 처음 DFS를 이용해 풀었을 때 시간 초과가 발생하여 DFS의 재귀를 사용해 문제를 풀었습니다. 
  해당 문제는 numbers 배열에 있는 숫자들의 `+`,`-` 를 조합하여 원하는 수(targetNumber)를 만드는 문제입니다.
  따라서 모든 경우를 따져보아야 하고, 결정된 한가지의 경우의 가장 깊은 Depth까지 가서 sum을 확인하는, 재귀를 이용한 DFS 방법을 사용했습니다. 
  