### PR TITLE
[Sol] 단지번호붙이기(#2667)

### DIFF
--- a/Algorithm_Study/Algorithm_Study.xcodeproj/project.pbxproj
+++ b/Algorithm_Study/Algorithm_Study.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0202887127E599A5000E794E /* 2667.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202887027E599A5000E794E /* 2667.swift */; };
 		0209E8A327C3C04900AFCF71 /* 1966.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0209E8A227C3C04900AFCF71 /* 1966.swift */; };
 		02227B0B27C53B4A00E7CFC5 /* 14713.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02227B0A27C53B4A00E7CFC5 /* 14713.swift */; };
 		023A3A4627D4B0AB00F56686 /* 1260.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A3A4527D4B0AA00F56686 /* 1260.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0202887027E599A5000E794E /* 2667.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 2667.swift; sourceTree = "<group>"; };
 		0209E8A227C3C04900AFCF71 /* 1966.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1966.swift; sourceTree = "<group>"; };
 		02227B0A27C53B4A00E7CFC5 /* 14713.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 14713.swift; sourceTree = "<group>"; };
 		023A3A4527D4B0AA00F56686 /* 1260.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 1260.swift; sourceTree = "<group>"; };
@@ -60,6 +62,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0202886F27E5996A000E794E /* Week7 */ = {
+			isa = PBXGroup;
+			children = (
+				0202887027E599A5000E794E /* 2667.swift */,
+			);
+			path = Week7;
+			sourceTree = "<group>";
+		};
 		023A3A4427D4B08100F56686 /* Week5 */ = {
 			isa = PBXGroup;
 			children = (
@@ -102,6 +112,7 @@
 				023A3A4927D4C8D600F56686 /* Week4 */,
 				023A3A4427D4B08100F56686 /* Week5 */,
 				02F8198727DE405A0084F0AD /* Week6 */,
+				0202886F27E5996A000E794E /* Week7 */,
 			);
 			path = Algorithm_Study;
 			sourceTree = "<group>";
@@ -204,6 +215,7 @@
 				023A3A4D27D4C8D600F56686 /* 1021.swift in Sources */,
 				02B5CB2D27C0CADA00981B7B /* 10845.swift in Sources */,
 				02F8198927DE41200084F0AD /* 타겟넘버.swift in Sources */,
+				0202887127E599A5000E794E /* 2667.swift in Sources */,
 				023A984327B7F6CC00117DA2 /* 10828.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Algorithm_Study/Algorithm_Study.xcodeproj/xcuserdata/hansolkim.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Algorithm_Study/Algorithm_Study.xcodeproj/xcuserdata/hansolkim.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,22 @@
    uuid = "A2A9D5CD-F7A1-444A-A3AE-C1E58A3759E0"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "A4612F77-DDC3-4612-BEBE-D8F74D4588D1"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Algorithm_Study/Week7/2667.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "32"
+            endingLineNumber = "32"
+            landmarkName = "bfs(x:y:)"
+            landmarkType = "9">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/Algorithm_Study/Algorithm_Study/Week7/2667.swift
+++ b/Algorithm_Study/Algorithm_Study/Week7/2667.swift
@@ -1,0 +1,91 @@
+//
+//  2667.swift
+//  Algorithm_Study
+//
+//  Created by 김한솔 on 2022/03/19.
+//
+
+import Foundation
+
+func mySolutionOf2667() {
+    
+    let N = Int(readLine()!)!
+    var _map = [[Int]]()
+    var complexes = [Int]()
+    
+    for _ in 0..<N {
+        _map.append(readLine()!.map{Int(String($0))!})
+    }
+    
+    for y in 0..<N {
+        for x in 0..<N {
+            if _map[y][x] == 1 {
+                complexes.append(bfs(x: x, y: y))
+            }
+        }
+    }
+    
+    print(complexes.count)
+    complexes.sorted()
+        .forEach {print($0)}
+    
+    func bfs( x:Int, y: Int) -> Int {
+        var homeCount = 1
+        var toVisitQueue = [(x: x, y: y)]
+        _map[y][x] = 0
+        
+        while !toVisitQueue.isEmpty {
+            let currentPosition = toVisitQueue.removeFirst()
+            
+            for d in [(x: 1, y: 0), (x: -1, y: 0), (x: 0, y: 1), (x: 0, y: -1)] {
+                let (nextX, nextY) = (currentPosition.x + d.x, currentPosition.y + d.y)
+                
+                if (0..<N).contains(nextX) && (0..<N).contains(nextY) && _map[nextY][nextX] == 1 {
+                    homeCount += 1
+                    _map[nextY][nextX] = 0
+                    toVisitQueue.append((nextX, nextY))
+                }
+            }
+        }
+        
+        return homeCount
+    }
+}
+
+func mySolutionOf2667_2() {
+    let N = Int(readLine()!)!
+    var _map = [[Int]]()
+    var complexes = [Int]()
+    
+    for _ in 0..<N {
+        _map.append(readLine()!.map{Int(String($0))!})
+    }
+    
+    for y in 0..<N {
+        for x in 0..<N {
+            if _map[y][x] == 1 {
+                complexes.append(dfs(x: x, y: y))
+            }
+        }
+    }
+    
+    print(complexes.count)
+    complexes.sorted()
+        .forEach {print($0)}
+    
+    func dfs( x:Int, y: Int) -> Int {
+        var homeCount = 1
+        _map[y][x] = 0
+        
+            for d in [(x: 1, y: 0), (x: -1, y: 0), (x: 0, y: 1), (x: 0, y: -1)] {
+                let (nextX, nextY) = (x + d.x, y + d.y)
+                
+                if (0..<N).contains(nextX) && (0..<N).contains(nextY) && _map[nextY][nextX] == 1 {
+                    _map[nextY][nextX] = 0
+                    homeCount += dfs(x: nextX, y: nextY)
+                }
+            }
+        
+        return homeCount
+    }
+}

--- a/Algorithm_Study/Algorithm_Study/main.swift
+++ b/Algorithm_Study/Algorithm_Study/main.swift
@@ -41,3 +41,6 @@ mySolutionOf2178()
 
 //0x09BFS 프로그래머스 타겟넘버 출력
 print(mySolutionOf타겟넘버(numbers: [1,1,1,1,1], target: 3))
+
+//0x09BFS 백준 2667 출력
+mySolutionOf2667()

--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@
 - [#BOJ2178](https://www.acmicpc.net/problem/2178) [[풀이]](./Algorithm_Study/Algorithm_Study/Week6/2178.swift)
 
 - [#Programmers-타겟넘버](https://programmers.co.kr/learn/courses/30/lessons/43165#qna) [[풀이]](./Algorithm_Study/Algorithm_Study/Week6/타겟넘버.swift)
+
+- [#BOJ2667](https://www.acmicpc.net/problem/2667) [[풀이]](./Algorithm_Study/Algorithm_Study/Week7/2667.swift)
+


### PR DESCRIPTION
# BFS
### 2667-단지번호붙이기
- BFS를 이용한 문제 풀이
```swift
let N = Int(readLine()!)!
var _map = [[Int]]()
var complexes = [Int]()

for _ in 0..<N {
    _map.append(readLine()!.map{Int(String($0))!})
}

for y in 0..<N {
    for x in 0..<N {
        if _map[y][x] == 1 {
            complexes.append(bfs(x: x, y: y))
        }
    }
}

print(complexes.count)
complexes.sorted()
    .forEach {print($0)}

func bfs( x:Int, y: Int) -> Int {
    var homeCount = 1
    var toVisitQueue = [(x: x, y: y)]
    _map[y][x] = 0
    
    while !toVisitQueue.isEmpty {
        let currentPosition = toVisitQueue.removeFirst()
        
        for d in [(x: 1, y: 0), (x: -1, y: 0), (x: 0, y: 1), (x: 0, y: -1)] {
            let (nextX, nextY) = (currentPosition.x + d.x, currentPosition.y + d.y)
            
            if (0..<N).contains(nextX) && (0..<N).contains(nextY) && _map[nextY][nextX] == 1 {
                homeCount += 1
                _map[nextY][nextX] = 0
                toVisitQueue.append((nextX, nextY))
            }
        }
    }
    
    return homeCount
}
```
- 시도한 접근 방법
  기존에 시도했던 방법과 동일하게, _map에서의 해당 좌표 값이 1인 곳에서 BFS를 이용해 다음에 이동할 구간을 찾았습니다. 그리고 이동한 좌표의 값을 0으로 바꾸고 해당 좌표에서 이동할 수 있는 좌표(_map상 인접한 좌표값이 1인 곳)를 toVisitQueue에 넣어주고 homeCount+=1을 한 후, toVisitQueue가 비어있을 때까지 반복하여 한 단지에 있는 집의 개수를 구했습니다.
그리고 bfs 메서드를 빠져나간 후, for문을 이용해 _map[y][x] == 1 인 다음 단지를 찾았고 해당 단지에서도 집의 개수를 위와 같은 방법으로 구했습니다.

- DFS를 이용한 문제 풀이
```swift
let N = Int(readLine()!)!
var _map = [[Int]]()
var complexes = [Int]()

for _ in 0..<N {
    _map.append(readLine()!.map{Int(String($0))!})
}

for y in 0..<N {
    for x in 0..<N {
        if _map[y][x] == 1 {
            complexes.append(dfs(x: x, y: y))
        }
    }
}

print(complexes.count)
complexes.sorted()
    .forEach {print($0)}

func dfs( x:Int, y: Int) -> Int {
    var homeCount = 1
    _map[y][x] = 0
    
        for d in [(x: 1, y: 0), (x: -1, y: 0), (x: 0, y: 1), (x: 0, y: -1)] {
            let (nextX, nextY) = (x + d.x, y + d.y)
            
            if (0..<N).contains(nextX) && (0..<N).contains(nextY) && _map[nextY][nextX] == 1 {
                _map[nextY][nextX] = 0
                homeCount += dfs(x: nextX, y: nextY)
            }
        }
    
    return homeCount
}
```
- 시도한 접근 방법
  데일의 코드를 보고 DFS를 사용해서 풀 수 있음을 알게 됐고, 제 코드를 조금 변형해 DFS를 이용한 문제 풀이 방법을 만들었습니다.
  BFS와 유사하지만, DFS를 이용하기 때문에 어떤 좌표에서 인접한 이동할 수 있는 좌표가 없을 때까지 재귀를 이용해 이동하면서 한 단지의 집의 개수를 구했습니다.
  그리고 한 단지의 집의 개수를 모두 찾으면 DFS 메서드를 빠져나갔고, BFS와 마찬가지로 for문을 이용해 다음 단지를 찾아 다시 DFS 메서드를 실행시키는 방법으로 문제를 풀 수 있었습니다.